### PR TITLE
DEP-33539: Fix SCSS

### DIFF
--- a/src/tags/header.riot
+++ b/src/tags/header.riot
@@ -1,5 +1,5 @@
 <app-header>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
       <span class="navbar-brand" if={ props.data }>
         { props.data.document.title + ' - ' }<name name={ props.data.demographics.name } class="text-muted"/>
       </span>

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -13,11 +13,7 @@ sialia {
     background-color: $body-bg;
 
     .sialia-body {
-        padding-top: 70px;
-    }
-
-    #headerMenu.fixed-top {
-        position: fixed !important;
+        padding-top: 20px;
     }
 
     h1 {


### PR DESCRIPTION
This pull request updates the behavior and styling of the header navigation bar to improve its positioning and appearance. The main focus is on changing the header from a fixed position to a sticky position and cleaning up related CSS.

Header positioning and styling updates:

* Changed the navigation bar in `header.riot` from `fixed-top` to `sticky-top` to use CSS sticky positioning instead of fixed positioning, which can improve layout and scrolling behavior.
* Removed unnecessary padding and fixed positioning CSS rules related to the header from `styles.scss`, as these are no longer needed with the sticky positioning.