### PR TITLE
Install git hook via prepare instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
         "format": "oxfmt",
         "format:check": "oxfmt --check",
         "install-hooks": "node ./utils/install-git-hooks.js",
-        "preinstall": "npm whoami || npm login",
-        "postinstall": "npm run install-hooks"
+        "preinstall": "npm whoami || npm login"
     },
     "dependencies": {
         "@kno2/bluebutton": "0.6.14",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "format": "oxfmt",
         "format:check": "oxfmt --check",
         "install-hooks": "node ./utils/install-git-hooks.js",
-        "preinstall": "npm whoami || npm login"
+        "preinstall": "npm whoami || npm login",
+        "prepare": "npm run install-hooks"
     },
     "dependencies": {
         "@kno2/bluebutton": "0.6.14",


### PR DESCRIPTION
## Problem
`@kno2/ccdaview` ships `postinstall: "npm run install-hooks"` (added in #117, live in published 2.0.4). npm runs a dependency's lifecycle scripts on install, so this executes in every **consumer** of the package — including **kno2fy-web**. The installer lives in `utils/`, which isn't in the published package (`files: ["dist/"]`), so it fails with `MODULE_NOT_FOUND` and breaks the consumer's `npm install`.

## Fix
Swap `postinstall` → **`prepare`**:

```diff
-        "postinstall": "npm run install-hooks"
+        "prepare": "npm run install-hooks"
```

`prepare` runs on a plain `npm install` **inside this repo** (so contributors still get the pre-commit hook auto-installed), but npm does **not** run a dependency's `prepare` when it's installed from the registry — so consumers never execute it. Same mechanism husky v9 uses. This also avoids the stray `.git/hooks` concern since it never runs inside `node_modules`.

`install-hooks` (manual) and `preinstall` are unchanged.

Note: `prepare` also runs during `npm publish`/`npm pack` on the release runner, where it harmlessly writes the hook into the ephemeral checkout (and the publish workflow installs with `--ignore-scripts`).

## Follow-up
After merge, cut a release (2.0.5) and bump `@kno2/ccdaview` in kno2fy-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
