### PR TITLE
Internal dependabot updates 07-30-2026

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4099,15 +4099,22 @@
             }
         },
         "node_modules/bootstrap": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-            "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
             "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
+            "license": "MIT",
             "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/bootstrap"
-            },
             "peerDependencies": {
                 "jquery": "1.9.1 - 3",
                 "popper.js": "^1.16.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "typescript": "5.9.3",
                 "webpack": "5.104.1",
                 "webpack-cli": "6.0.1",
-                "webpack-dev-server": "5.2.5"
+                "webpack-dev-server": "5.2.6"
             },
             "peerDependencies": {
                 "bootstrap": "^4.2.1",
@@ -6099,9 +6099,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -6515,9 +6515,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.10",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6534,7 +6534,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -8123,9 +8123,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-            "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8147,7 +8147,7 @@
                 "graceful-fs": "^4.2.6",
                 "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
+                "launch-editor": "^2.14.1",
                 "open": "^10.0.3",
                 "p-retry": "^6.2.0",
                 "schema-utils": "^4.2.0",
@@ -8363,10 +8363,11 @@
             "license": "MIT"
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "typescript": "5.9.3",
         "webpack": "5.104.1",
         "webpack-cli": "6.0.1",
-        "webpack-dev-server": "5.2.5"
+        "webpack-dev-server": "5.2.6"
     },
     "peerDependencies": {
         "bootstrap": "^4.2.1",


### PR DESCRIPTION
Follow-up batch for 07-30-2026, covering the dependabot PRs that opened right after the
07-29 batch merged. Dependency files only.

### Updated (package.json)
- webpack-dev-server: 5.2.5 -> 5.2.6  (supersedes #135)

Worth noting #135 used to be the `5.2.5 -> 6.0.0` major that the 07-29 batch excluded.
Rebasing it after that batch merged re-scoped it to a 5.2.6 patch, so it is now in scope.

### Lockfile-only (transitive / security)
- postcss: 8.5.10 -> 8.5.25  (supersedes #133)
- ws: 8.18.3 -> 8.21.1  (supersedes #134)
- bootstrap: 4.6.0 -> 4.6.2  (supersedes #82)

`bootstrap` is a peerDependency here (`^4.2.1`), not a direct dependency, so 4.6.2 needed
no package.json change. Same story as #135: #82 was excluded from the 07-29 batch as a
`4.6.0 -> 5.0.0` major, and rebasing it after that batch merged re-scoped it to a 4.6.2
patch. `bootswatch` stays at 4.6.0; it is a Bootstrap 4 theme and a patch-level bump
underneath it is fine, which the build confirms.

### Held back
- oxfmt: still 0.57.0. Bumping it to 0.61.0 changes markdown formatting and, with it
  installed, the pre-commit hook rewrites any staged markdown, so the bump and a
  `CONTRIBUTING.md` reformat cannot be separated. Deferred, as in the 07-29 batch.
- oxlint: still 1.72.0, matching what `@kno2/oxlint-config@1.0.6` declares.

### Still open, not included
- @babel/core / @babel/preset-env / @babel/register #127 - still all majors (7.x -> 8.x).

package-lock.json was regenerated by npm and verified stable: two consecutive
`npm install` runs on node 24.18.0 (`.nvmrc`, npm 11.16.0) leave it byte-identical and
report "up to date".

Verified with `npm run lint`, `npm run format:check` and `npm run build`.
