### PR TITLE
KEW-11298: Stop bundling Bootstrap and Font Awesome, scope own styles

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,12 @@
             name="viewport"
             content="width=device-width, initial-scale=1" />
         <title>Sialia</title>
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" />
     </head>
     <body>
         <sialia></sialia>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,7 @@
                 "core-js": "3.47.0",
                 "date-fns": "4.1.0",
                 "dragula": "3.7.3",
-                "font-awesome": "4.7.0",
                 "lodash": "4.18.1",
-                "popper.js": "1.16.1",
                 "riot": "10.1.2"
             },
             "devDependencies": {
@@ -31,7 +29,6 @@
                 "@types/lodash": "4.17.21",
                 "@types/node": "24.10.4",
                 "babel-loader": "10.1.1",
-                "bootswatch": "4.6.0",
                 "css-loader": "7.1.2",
                 "mini-css-extract-plugin": "2.9.4",
                 "oxfmt": "0.57.0",
@@ -47,7 +44,8 @@
                 "webpack-dev-server": "5.2.6"
             },
             "peerDependencies": {
-                "bootstrap": "^4.2.1",
+                "bootstrap": "^5.3.0",
+                "font-awesome": "^4.7.0",
                 "jquery": "^3.7.1"
             }
         },
@@ -3114,6 +3112,17 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
         "node_modules/@riotjs/compiler": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/@riotjs/compiler/-/compiler-10.0.1.tgz",
@@ -4099,10 +4108,9 @@
             }
         },
         "node_modules/bootstrap": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
-            "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+            "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
             "funding": [
                 {
                     "type": "github",
@@ -4116,15 +4124,8 @@
             "license": "MIT",
             "peer": true,
             "peerDependencies": {
-                "jquery": "1.9.1 - 3",
-                "popper.js": "^1.16.1"
+                "@popperjs/core": "^2.11.8"
             }
-        },
-        "node_modules/bootswatch": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-4.6.0.tgz",
-            "integrity": "sha512-Yr6YqFBC8jwTzoJoLViYlvO97IhPWGqZEm+6FXHfD/G6gbUok6sZkdXxdh4Zb6iCGEwr9p7zGCn38yKQD/bh2Q==",
-            "dev": true
         },
         "node_modules/braces": {
             "version": "3.0.3",
@@ -5302,6 +5303,7 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
             "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.3"
             }
@@ -6509,16 +6511,6 @@
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/popper.js": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-            "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
         "core-js": "3.47.0",
         "date-fns": "4.1.0",
         "dragula": "3.7.3",
-        "font-awesome": "4.7.0",
         "lodash": "4.18.1",
-        "popper.js": "1.16.1",
         "riot": "10.1.2"
     },
     "devDependencies": {
@@ -45,7 +43,6 @@
         "@types/lodash": "4.17.21",
         "@types/node": "24.10.4",
         "babel-loader": "10.1.1",
-        "bootswatch": "4.6.0",
         "css-loader": "7.1.2",
         "mini-css-extract-plugin": "2.9.4",
         "oxfmt": "0.57.0",
@@ -61,7 +58,8 @@
         "webpack-dev-server": "5.2.6"
     },
     "peerDependencies": {
-        "bootstrap": "^4.2.1",
+        "bootstrap": "^5.3.0",
+        "font-awesome": "^4.7.0",
         "jquery": "^3.7.1"
     }
 }

--- a/src/tags/header.riot
+++ b/src/tags/header.riot
@@ -1,26 +1,27 @@
 <app-header>
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
+    <div class="container-fluid">
       <span class="navbar-brand" if={ props.data }>
         { props.data.document.title + ' - ' }<name name={ props.data.demographics.name } class="text-muted"/>
       </span>
       <span class="navbar-brand" if={ !props.data }>
         Loading...
       </span>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarText">
-      <ul class="navbar-nav ml-auto">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarText">
+        <ul class="navbar-nav ms-auto">
           <li class="nav-item dropdown" if={ props.sections && props.sections.length }>
-            <a class="jump-to nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="jump-to nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Jump to
             </a>
-            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="#">Top</a>
-            <div class="dropdown-divider"></div>
-                <a each={ section in props.sections } class="dropdown-item" href={ '#' + section.key }>
-                  <i class={ 'fa fa-' + section.icon } aria-hidden="true"></i>{ ' ' + section.display }
-                </a>
+            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+              <a class="dropdown-item" href="#">Top</a>
+              <div class="dropdown-divider"></div>
+              <a each={ section in props.sections } class="dropdown-item" href={ '#' + section.key }>
+                <i class={ 'fa fa-' + section.icon } aria-hidden="true"></i>{ ' ' + section.display }
+              </a>
             </div>
           </li>
           <li class={ props.showPreferences ? 'active' : '' } if={ props.sections }>
@@ -29,6 +30,7 @@
             </a>
           </li>
         </ul>
+      </div>
     </div>
   </nav>
 

--- a/src/tags/preference-section.riot
+++ b/src/tags/preference-section.riot
@@ -1,5 +1,5 @@
 <preference-section>
-  <li class="list-group-item preferences-section text-right">
+  <li class="list-group-item preferences-section text-end">
     <label class="checkbox-inline pull-left">
       <input type="checkbox" checked={ props.section.enabled } onchange={ change }>{ ' ' }<i class={ 'fa fa-' + props.section.icon }></i>{ ' ' + props.section.display }
     </label>

--- a/styles/_custom.scss
+++ b/styles/_custom.scss
@@ -1,29 +1,32 @@
-.bg-dark {
-    background-color: #000 !important;
-}
+sialia {
+    font-size: 15px;
 
-.panel {
-    margin-bottom: 21px;
-    background-color: #fff;
-    border: 1px solid transparent;
-    border-radius: 0;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-    border-color: #ddd;
-}
+    h3 {
+        font-size: 15px !important;
+    }
 
-h3,
-body {
-    font-size: 15px !important;
-}
+    .bg-dark {
+        background-color: #000 !important;
+    }
 
-.navbar-dark .navbar-toggler {
-    color: #fff;
-}
+    .panel {
+        margin-bottom: 21px;
+        background-color: #fff;
+        border: 1px solid transparent;
+        border-radius: 0;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+        border-color: #ddd;
+    }
 
-.jump-to:after {
-    margin: -2px 0 !important;
-    border-top: 0.25em solid #8b9296 !important;
-    border-left: 0.25em solid transparent !important;
-    border-right: 0.25em solid transparent !important;
-    // border: none !important;
+    .navbar-dark .navbar-toggler {
+        color: #fff;
+    }
+
+    .jump-to:after {
+        margin: -2px 0 !important;
+        border-top: 0.25em solid #8b9296 !important;
+        border-left: 0.25em solid transparent !important;
+        border-right: 0.25em solid transparent !important;
+        // border: none !important;
+    }
 }

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1,8 +1,3 @@
-$fa-font-path: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/fonts/';
-@import '~font-awesome/scss/font-awesome';
-@import '~bootstrap/scss/bootstrap';
-@import '~bootswatch/dist/cosmo/variables';
-@import '~bootswatch/dist/cosmo/bootswatch';
 @import '~dragula/dist/dragula';
 @import 'custom';
 
@@ -69,7 +64,17 @@ sialia {
     }
 
     .alert-mild {
-        @include alert-variant($mild, $mild, #000);
+        color: #000;
+        background-color: $mild;
+        border-color: $mild;
+
+        hr {
+            border-top-color: darken($mild, 5%);
+        }
+
+        .alert-link {
+            color: #000;
+        }
     }
 
     .reasons {


### PR DESCRIPTION
Part of the kno2fy-web Bootstrap 4 to 5 migration (KEW-11265).

## The problem

ccdaview declared `bootstrap` as a **peer** dependency but also compiled the entire framework into `dist/sialia.css`:

```scss
@import '~bootstrap/scss/bootstrap';
@import '~bootswatch/dist/cosmo/variables';
@import '~bootswatch/dist/cosmo/bootswatch';
@import '~font-awesome/scss/font-awesome';
```

kno2fy-web imports `sialia.css` app-wide, so it was loading a complete **Bootstrap 4** stylesheet alongside its own Bootstrap 5, plus a duplicate Font Awesome. That conflict masked the entire Bootstrap 5 migration: dropped BS4 classes in kno2fy-web still resolved, because ccdaview kept serving them.

`_custom.scss` also emitted unscoped global rules into the host, including `h3, body { font-size: 15px !important }`.

## Result

| | bytes |
|---|---|
| before | 187,691 |
| after dropping Bootstrap + Bootswatch | 33,018 |
| after dropping Font Awesome | **3,672** |

98% smaller. `sialia.css` now contains only dragula plus ccdaview's own scoped styles.

## Changes

- Removed the bootstrap, bootswatch and font-awesome imports; honor the peer contract instead
- Inlined the one Bootstrap mixin in use (`alert-variant`) with equivalent output
- `bootstrap` peer widened to `^5.3.0`; `font-awesome` moved from dependency to peer
- Demo gains bootstrap and font-awesome CDN links, since it previously relied on the bundle
- Removed the unused `bootswatch` devDependency and the dead `popper.js` dependency (BS4-only; BS5 uses `@popperjs/core`)
- `_custom.scss` scoped under `sialia`

## Bootstrap 5 markup migration

`data-toggle`/`data-target` to `data-bs-*`, `dropdown-menu-right` to `dropdown-menu-end`, `text-right` to `text-end`, `ml-auto` to `ms-auto`.

Plus one structural change: navbar contents are wrapped in `.container-fluid`. Bootstrap 4 shipped `.navbar { padding: .5rem 1rem }`; Bootstrap 5 sets `--bs-navbar-padding-x: 0` and expects a container to supply it. Without one the brand sat flush against the viewport edge.

## The one non-mechanical translation

`h3, body { font-size: 15px !important }` could not simply be nested, because `body` is never a descendant of `sialia`. It became:

```scss
sialia { font-size: 15px; }
sialia h3 { font-size: 15px !important; }
```

That preserves the 15px base inside the widget without imposing it on host applications. It is the one rule worth a visual check rather than a diff read.

## Verification

- Build 0 errors; lint and format clean; lockfile verified at a fixed point (re-ran, no further change)
- Selector audit of the built bundle: 60 selectors, 55 scoped under `sialia`, 4 dragula globals (`.gu-mirror`, `.gu-hide`, `.gu-unselectable`, `.gu-transit`, which must stay global because dragula appends its drag mirror to `document.body`), 1 pre-existing dead selector (below)
- Zero Bootstrap and zero Font Awesome markers remain in the output
- Confirmed kno2fy-web supplies its own Font Awesome via `font-awesome-charset.css`, so its 668 `fa fa-*` usages are unaffected

## Follow-ups, not in this PR

A published version is needed before kno2fy-web can drop its `bootstrap` override and its transitive `popper.js`.

`styles.scss` contains a pre-existing selector that has never matched:

```scss
.panel-body > ul:last-child > li:last-child > *:last-child {
    #demographics-summary &, & { margin-bottom: 0; }
}
```

`&` expands to the full parent chain, emitting `#demographics-summary sialia .panel-body > ...`, which requires `#demographics-summary` to be an ancestor of `sialia` when it is actually a descendant. Fixing it would activate currently-dead styling, so it was left alone.

ccdaview still declares a `jquery` peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
